### PR TITLE
Fix test

### DIFF
--- a/generators/entity-server/templates/quarkus/src/test/java/package/_partials/imports.ejs
+++ b/generators/entity-server/templates/quarkus/src/test/java/package/_partials/imports.ejs
@@ -76,6 +76,3 @@ import java.util.ArrayList;
     <%_ if (fieldsContainUUID === true) { _%>
 import java.util.UUID;
     <%_ } _%>
-    <%_ if (fieldsContainZonedDateTime === true) { _%>
-import static <%= packageName %>.TestUtil.sameInstant;
-    <%_ } _%>


### PR DESCRIPTION
Error build. 
import into a class of a non-existing assembly - "import static com.synq.testprimitive.TestUtil.sameInstant;"

------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project testprimitive: Compilation failure
[ERROR] /var/lib/jenkins/workspace/generated-applications/Testprimitive/src/test/java/com/synq/testprimitive/web/rest/TestprimitiveResourceTest.java:[29,1] cannot find symbol
[ERROR]   symbol:   static sameInstant
[ERROR]   location: class com.synq.testprimitive.TestUtil