### PR TITLE
Исправлено несоответствие наименования поля со ссылкой вспомогательной таблицы связи "многие ко многим"…

### DIFF
--- a/generators/entity-server/templates/quarkus/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/quarkus/src/main/java/package/domain/Entity.java.ejs
@@ -348,7 +348,7 @@ public class <%= asEntity(entityClass) %> extends <% if (databaseType === 'sql')
     }) -%>
         <%_ } _%>
     @JoinTable(name = "<%= joinTableName %>",
-               joinColumns = @JoinColumn(name = "<%= getColumnName(name) %>_id", referencedColumnName = "id"),
+               joinColumns = @JoinColumn(name = "<%= entityTableName %>_id", referencedColumnName = "id"),
                inverseJoinColumns = @JoinColumn(name = "<%= getColumnName(relationships[idx].relationshipName) %>_id", referencedColumnName = "id"))
         <%_ }
         } else if (databaseType === 'mongodb' || databaseType === 'couchbase') {


### PR DESCRIPTION
… в описании сущности и в описании создаваемой таблицы файла набора изменений liquibase, если наименование первой сущности содержит группы цифр или символов в верхнем регистре.  Исправил именно таким образом потому, что наименование столбца в added_entity.xml.ejs собирается конкатенацией из наименования таблицы и поля: `<column name="<%= entity.entityTableName %>_<%= field.columnName %>"`. Сформировать наименование столбца другим образом не представляется возможным, т.к. проблема именно из-за разных функция для преобразования camelCase в snake_case. Для полей использована hibernateSnakeCase, а для таблиц snakeCase.