### PR TITLE
Добавил кастомный маппинг для всех Set-ов при преобразовании в DTO. В…

### DIFF
--- a/generators/entity-server/templates/quarkus/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/quarkus/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -152,7 +152,7 @@ public class <%= asDto(entityClass) %> implements Serializable, BaseDTO {
     @ApiModelProperty(value = "<%- formatAsApiDescription(relationships[idx].javadoc) %>")
         <%_ } _%>
         <%_ if ((relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-many' && otherEntityIsEmbedded)) { _%>
-    public Set<<%= asDto(otherEntityNameCapitalized) %>> <%= relationshipFieldName %> = new HashSet<>();
+    public Set<<%= asDto(otherEntityNameCapitalized) %>> <%= relationshipFieldName %>;
         <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true && otherEntityIsEmbedded) { _%>
     public <%= asDto(otherEntityNameCapitalized) %> <%= relationshipFieldName %>;
         <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
@@ -186,7 +186,27 @@ public class <%= asDto(entityClass) %> implements Serializable, BaseDTO {
 
     @Override
     public int hashCode() {
-        return 31;
+        return Objects.hash(id
+        <%_ for (idx in fields) {
+            const fieldName = fields[idx].fieldName; _%>
+            , <%= fieldName %>
+        <%_ } _%>
+        <%_ for (idx in relationships) {
+            const relationshipFieldName = relationships[idx].relationshipFieldName;
+            const relationshipType = relationships[idx].relationshipType;
+            const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
+            const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
+            const ownerSide = relationships[idx].ownerSide; _%>
+        <%_ if ((relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-many' && otherEntityIsEmbedded)) { _%>
+            , <%= relationshipFieldName %>
+        <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true && otherEntityIsEmbedded) { _%>
+            , <%= relationshipFieldName %>
+        <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+            , <%= relationshipFieldName %>Id
+            <%_ if (otherEntityFieldCapitalized !== 'Id' && otherEntityFieldCapitalized !== '') { _%>
+                , <%= relationshipFieldName %><%= otherEntityFieldCapitalized %>
+        <%_ } } } _%>
+        );
     }
 
     @Override
@@ -222,5 +242,22 @@ public class <%= asDto(entityClass) %> implements Serializable, BaseDTO {
             ", <%= relationshipFieldName %><%= otherEntityFieldCapitalized %>='" + <%= relationshipFieldName %><%= otherEntityFieldCapitalized %> + "'" +
             <%_ } } } _%>
             "}";
+    }
+
+    public <%= asDto(entityClass) %>() {
+        <%_ for (idx in relationships) {
+            const relationshipFieldName = relationships[idx].relationshipFieldName;
+            const relationshipType = relationships[idx].relationshipType;
+            const otherEntityIsEmbedded = relationships[idx].otherEntity.embedded;
+            const ownerSide = relationships[idx].ownerSide;
+        _%>
+            <%_ if ((relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-many' && otherEntityIsEmbedded)) { _%>
+                <%= relationshipFieldName %> = new HashSet<>();
+            <%_ } _%>
+        <%_ } _%>
+    }
+
+    public <%= asDto(entityClass) %>(Long id) {
+        this.id = id;
     }
 }

--- a/generators/entity-server/templates/quarkus/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/quarkus/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -79,6 +79,8 @@ import org.mapstruct.*;
 import java.util.Objects;
 import java.util.UUID;
 <%_ } _%>
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Mapper for the entity {@link <%= asEntity(entityClass) %>} and its DTO {@link <%= asDto(entityClass) %>}.
@@ -153,6 +155,9 @@ _%>
         <%= asEntity(entityInstance) %>.id = id;
         return <%= asEntity(entityInstance) %>;
     }
+    default Set<<%= asDto(entityClass) %>> convertSet(Set<<%= asEntity(entityClass) %>> empSet) {
+        return empSet == null ? null : empSet.stream().map(field -> new <%= asDto(entityClass) %>(field.id)).collect(Collectors.toSet());
+        }
 <%_ } _%>
     <%_ if (uuidMapMethod) { _%>
 


### PR DESCRIPTION
… результате вместо множества полноценных объектов будет возвращаться множество объектов содержащих только идентификаторы [{"id", N1}, {"id", N2},...] (временное решение от зацикливания при ссылках на самого себя).

Единственное сомнение - добавил для всех типов (перечисления и т.д.). 
Предлагаю оставить это как временное решение, далее, думаю было бы логично, привести все ссылки привести к единому формату. Т.к. например единичные ссылки преобразуются в Long с Id и на роутер преобразует эти данные.